### PR TITLE
🌲 Fix UnboundLocalError during the call to tls_set_context🌲

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -422,7 +422,7 @@ def main():
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
 
-    client.tls_set_context(ssl_context)
+        client.tls_set_context(ssl_context)
 
     def stop_request(signum, frame):
         """Stop handler for SIGTERM and SIGINT.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
-paho-mqtt
-prometheus-client
+paho-mqtt==1.6.1
+prometheus-client==0.20.0


### PR DESCRIPTION
<!-- Please respect the guidelines - codestyle and unit tests - explained in CONTRIBUTING.md -->

# Fixes

## UnboundLocalError
**Description:**

<!-- Put here a simple description on what the change is supposed to do -->
When calling client.tls_set_context(ssl_context), an error occurs: 

```
UnboundLocalError: cannot access local variable 'ssl_context' where it is not associated with a value
```
Because the ssl_context variable may not be declared due to the settings.MQTT_ENABLE_TLS flag

**Before the commit:**

<!-- When relevant, please provide output, screenshot or example before the change -->
```
    client.tls_set_context(ssl_context)
                           ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'ssl_context' where it is not associated with a value
```

**After the commit:**

<!-- When relevant, please provide output, screenshot or example after the change -->
This error no longer occurs 🙂

## Versions
**Description:**

<!-- Put here a simple description on what the change is supposed to do -->
In the new version of paho-mqtt (2.0.0), a required parameter `callback_api_version` is expected. Therefore, an error occurred when starting

```
TypeError: Client.__init__() missing 1 required positional argument: 'callback_api_version'
```
**Latest versions** of paho mqtt are given below:
![image](https://github.com/twoics/mqtt-exporter/assets/73189877/344a81e9-6670-4b8a-a2d9-83638370c6ad)


**Before the commit:**

<!-- When relevant, please provide output, screenshot or example before the change -->
Core dependency versions were not installed

***base.txt:***
```
paho-mqtt
prometheus-client
```
**After the commit:**

<!-- When relevant, please provide output, screenshot or example after the change -->
***base.txt:***
```
paho-mqtt==1.6.1
prometheus-client==0.20.0
```
This error no longer occurs 🙂

