### PR TITLE
🥔 Replace encoding from utf-8 to latin-1 in message processing 🥔

### DIFF
--- a/mqtt_exporter/processing/middleware/plain.py
+++ b/mqtt_exporter/processing/middleware/plain.py
@@ -13,4 +13,4 @@ class PlainTextInplaceProcessMiddleware(InplaceProcessMiddleware):
         try:
             json.loads(message.payload)
         except JSONDecodeError:
-            message.payload = json.dumps({'msg': message.payload.decode("utf-8")})
+            message.payload = json.dumps({'msg': message.payload.decode("latin-1")})


### PR DESCRIPTION
# Fixes 

**Description:**

When sending messages of this type `[2, 25, 222]` the `decode('utf-8')` operation cannot handle this and fails with an error

**Before the commit:**

Decoding used `utf-8`

**After the commit:**

Decoding used `latin-1`
