### PR TITLE
🫧 Catch UnicdoeDecodeError when loads json in message processing 🫧

### DIFF
--- a/mqtt_exporter/processing/middleware/plain.py
+++ b/mqtt_exporter/processing/middleware/plain.py
@@ -12,5 +12,5 @@ class PlainTextInplaceProcessMiddleware(InplaceProcessMiddleware):
         message = data['message']
         try:
             json.loads(message.payload)
-        except JSONDecodeError:
+        except (JSONDecodeError, UnicodeDecodeError):
             message.payload = json.dumps({'msg': message.payload.decode("latin-1")})


### PR DESCRIPTION
# Fixes 

**Description:**
Encoding error not handled when serializing json

**Before the commit:**

This code can raise `encoding` error
```python
 json.loads(message.payload)
``` 

**After the commit:**

This error handle now